### PR TITLE
Raw - small adjustments to improve stability

### DIFF
--- a/src/Raw.cpp
+++ b/src/Raw.cpp
@@ -61,8 +61,8 @@ struct RawModule : Module {
 		configParam(PARAM_GAIN_IN, -20.f, 20.f, 15.f, "Input gain", "dB");
 		configParam(PARAM_FN, 20.f, 2000.f, 1000.f, "Resonance frequency", "Hz");
 		configParam(PARAM_C, -6.f, -3.f, -4.f, "Damping coefficient");
-		configParam(PARAM_K, 0.01f, 1.f, 0.5f, "Nonlinearity parameter");
-		configParam(PARAM_KMULT, -1.f, 1.f, 0.f, "Nonlinearity asymmetry", "", 10.f);
+		configParam(PARAM_K, 0.1f, 1.f, 0.5f, "Nonlinearity parameter");
+		configParam(PARAM_KMULT, -1.f, 1.f, 0.f, "Nonlinearity asymmetry", "", 5.f);
 		configParam(PARAM_GAIN_OUT, -20.f, 20.f, -10.f, "Output gain", "dB");
 		onReset();
 		paramDivider.setDivision(64);
@@ -84,13 +84,16 @@ struct RawModule : Module {
 		Fn = params[PARAM_FN].getValue();
 		c = pow(10.f, params[PARAM_C].getValue());
 		k = params[PARAM_K].getValue();
-		k3 = k * pow(10.f, params[PARAM_KMULT].getValue());
+		k3 = k * pow(5.f, params[PARAM_KMULT].getValue());
 		out_gain = pow(10.f, params[PARAM_GAIN_OUT].getValue() / 20.f);
 		// for normalization of [-1,1] to output voltage [-5V,5V]
 		out_gain *= 5.0f; 
 
 		Ts = APP->engine->getSampleTime();
 		Ts0001 = Ts / 0.0001f;
+
+		// scale damping with frequency and nonlinearity to preserve stability
+		c *= pow(2.f, pow(Fn / 2000.f, 10.f)) * (1.f + 20.f * pow(1.f - k, 2.f));
 
 		// angular frequency
 		Wn = 2.0f * M_PI * Fn;


### PR DESCRIPTION
Made some small adjustments to the Raw algorithm to improve stability. Note that I'm not actually changing the physics simulation, only steering the parameter choices away from potential instabilities. A couple things you may want to consider:

- With this change, you may want to increase the default Output Gain, since it comes through a little quiet. That said, after you decrease the "c" parameter the volume goes up a lot.

- Maybe remove the extra limiter? It can't hurt, but may no longer be necessary.

